### PR TITLE
make loadDynamicData() and saveDynamicData() public methods

### DIFF
--- a/src/ESPAsync_WiFiManager_Lite.h
+++ b/src/ESPAsync_WiFiManager_Lite.h
@@ -1555,6 +1555,7 @@ class ESPAsync_WiFiManager_Lite
 
     unsigned long configTimeout;
     bool hadConfigData = false;
+    bool hadDynamicData = false;
 
     bool isForcedConfigPortal   = false;
     bool persForcedConfigPortal = false;


### PR DESCRIPTION
See discussion #17.
Also added a flag to not load data twice, if already loaded.
Also renamed `CREDENTIALS_FILENAME` and `wm_cred.dat` to `DYNAMIC_DATA_FILENAME` and `wm_dynamic.dat` to align with method names (the credentials are stored in `CONFIG_FILENAME`).
I tested/compiled the code on ESP8266 with LittleFS and EEPROM.
What I did not check is ESP32, as I do not have the dev env.